### PR TITLE
fix: Make tput detection work on linux

### DIFF
--- a/.ntw.sh
+++ b/.ntw.sh
@@ -21,7 +21,7 @@ if [ "${USE_TPUT:-}" = "" ]; then
   set +e
   tput sgr0 2>/tmp/tput.txt
   if [ $? -eq 0 ]; then
-    if [ $(wc -c /tmp/tput.txt | tr -s " " | cut -d " " -f 2) -gt 3 ]; then
+    if [ $(wc -c /tmp/tput.txt | sed -E 's/^ +//g' | tr -s " " | cut -d " " -f 1) -gt 3 ]; then
       USE_TPUT=0
     else
       USE_TPUT=1


### PR DESCRIPTION
Mac `wc` prefixed the count with spaces.
Linux did not.

This handles both correctly.
